### PR TITLE
v1.0.7 changes

### DIFF
--- a/assets/js/wcev_main.js
+++ b/assets/js/wcev_main.js
@@ -2,7 +2,7 @@
   * @description: This file is part of the WC External Variations plugin for Wordpress
   * @author: Impossible Dreams Network (https://web.impossibledreams.net)
   * @requires: jquery
-  * @version: 1.0.6
+  * @version: 1.0.7
   * @link: https://web.impossibledreams.net
   *
   * @copyright: Copyright (c) 2018-2020 Impossible Dreams Network (email: wp-plugins@impossibledreams.net)

--- a/assets/js/wcev_main.js
+++ b/assets/js/wcev_main.js
@@ -10,6 +10,34 @@
   */
 (function($){
   $(document).ready(function(){
+    // Change button text back when variations are reset
+    $('.variations_form').on('reset_data', function ( event ) {
+        if (this.dataset.old_add_to_cart_text) {
+           var add_to_cart_button = $(this).find('.single_add_to_cart_button')[0];
+           add_to_cart_button.textContent = this.dataset.old_add_to_cart_text;
+        }
+    });
+
+    // Hook onto 'show_variation' in order to change the 'Add to Cart' button
+    $('.variations_form').on("show_variation", function ( event, variation ) {
+      var add_to_cart_button = $(this).find('.single_add_to_cart_button')[0];
+
+      if (variation._wcev_add_to_cart_text) {
+        // Save old button text before setting the new one
+        if (!this.dataset.old_add_to_cart_text) {
+           this.dataset.old_add_to_cart_text = add_to_cart_button.textContent;
+        }
+
+        // Set the button text if needed
+        add_to_cart_button.textContent = variation._wcev_add_to_cart_text;
+      } else {
+        // Check if old cart text is saved, then reset. This is for an edge case when button text isn't set for one variation.
+        if (this.dataset.old_add_to_cart_text) {
+          add_to_cart_button.textContent = this.dataset.old_add_to_cart_text;
+        }
+      }
+    });
+
     // Hook custom event on the 'Add to Cart' button in WooCommerce, for variations only
     $('.woocommerce-variation-add-to-cart .single_add_to_cart_button').click(function(event) {
       // Error handling in case there is an issue with the URL

--- a/readme.txt
+++ b/readme.txt
@@ -33,11 +33,19 @@ set this field and then use the provided shortcode to display it. The purpose is
 
 There is also an external status field for tracking things like stock status separately from internal WooCommerce functionality.
 
+There is now ability to specify the 'Add to Button' text in a specific variation. If the global setting is set, the variation-specific field will override it.
+
+= Settings =
+To change settings, go to WooCommerce Settings -> Products -> External Variations.
+The following are available:
+* Ability to change if links open in new or same window
+* Ability to override the 'Add to Button' text for all external variations
+
 = More Details =
 
 Please note that this plugin has only been tested in a vanilla WordPress / WooCommerce
 installation without any other plugins. If you have other plugins that modify
-the functionality of the *Add to Cart* button, this plugin may not work or 
+the functionality of the *Add to Cart* button, this plugin may not work or
 cause unintended consequences.
 
 Development of this plugin is done at [Github](https://github.com/impossibledreams/wc-external-variations)
@@ -63,10 +71,11 @@ This update adds settings to control whether links open in the same or new tab.
 == Changelog ==
 
 = 1.0.7 =
-* Tested with Wordpress v5.5 and WooCommerce v4.4.0
+* Tested with Wordpress v5.5 and WooCommerce v4.4.1
+* Added ability to change the 'Add to Cart' text on global and variation-specific basis (#3).
 
 = 1.0.6 =
-* Added settings option to control whether links open in the same or new tab
+* Added settings option to control whether links open in the same or new tab (#4).
 * Tested with Wordpress v5.4.1 and WooCommerce v4.1.1
 
 = 1.0.5 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, external, variations, variable
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Requires at least: 4.7
-Tested up to: 5.4.1
+Tested up to: 5.5.0
 Stable tag: trunk
 Requires PHP: 5.2.4
 
@@ -61,6 +61,9 @@ click on *Add to Cart*.
 This update adds settings to control whether links open in the same or new tab.
 
 == Changelog ==
+
+= 1.0.7 =
+* Tested with Wordpress v5.5 and WooCommerce v4.4.0
 
 = 1.0.6 =
 * Added settings option to control whether links open in the same or new tab

--- a/wc-external-variations.php
+++ b/wc-external-variations.php
@@ -11,7 +11,7 @@
  * Contributors: impossibledreams, yakovsh
  *
  * WC requires at least: 4.0.0
- * WC tested up to: 4.4.0
+ * WC tested up to: 4.4.1
  *
  * Copyright: Copyright (c) 2018-2020 Impossible Dreams Network (email: wp-plugins@impossibledreams.net)
  * License: GNU General Public License v3.0
@@ -102,6 +102,19 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
                     ),
 
                     array(
+                        'id'       => 'wcev_add_to_cart_text',
+                        'type'     => 'text',
+                        'title'    => __( 'Text to the "Add to Cart" button', 'wcev-domain' ),
+                        'options'  => array(
+                            'new_window'  => __( 'New window/tab', 'wcev-domain' ),
+                            'same_window' => __( 'Same window/tab', 'wcev-domain' ),
+                        ),
+                        'default'  => '',
+                        'desc'     => __( 'Configures custom text for the "Add to Cart" button, leave empty not to override', 'wcev-domain' ),
+                        'desc_tip' => true,
+                    ),
+
+                    array(
                         'type'  => 'sectionend',
                         'id'    => 'external_variations_section',
                     ),
@@ -165,7 +178,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
                         if ( !empty( $values ) ) {
 				foreach ( $values as $value ) {
 					$return .= $value;
-				}				
+				}
 			}
 		}
 
@@ -190,10 +203,10 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	     */
 	    function wcev_filter_show_fields( $loop, $variation_data, $variation ) {
 	       // Load and show the External URL field
-	       woocommerce_wp_text_input( 
-		array( 
-		    'id'          => '_wcev_external_url[' . $variation->ID . ']', 
-		    'label'       => __( 'External URL', 'woocommerce' ), 
+	       woocommerce_wp_text_input(
+		array(
+		    'id'          => '_wcev_external_url[' . $variation->ID . ']',
+		    'label'       => __( 'External URL', 'woocommerce' ),
 		    'placeholder' => 'https://',
 		    'desc_tip'    => 'true',
 		    'description' => __( 'Enter the URL of the external product.', 'woocommerce' ),
@@ -202,10 +215,10 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	       );
 
 	       // Load and show the External SKU field
-	       woocommerce_wp_text_input( 
-		array( 
-		    'id'          => '_wcev_external_sku[' . $variation->ID . ']', 
-		    'label'       => __( 'External SKU', 'wc-external-variations' ), 
+	       woocommerce_wp_text_input(
+		array(
+		    'id'          => '_wcev_external_sku[' . $variation->ID . ']',
+		    'label'       => __( 'External SKU', 'wc-external-variations' ),
 		    'placeholder' => '',
 		    'desc_tip'    => 'true',
 		    'description' => __( 'Enter the SKU of the external product', 'wc-external-variations' ),
@@ -214,16 +227,28 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	       );
 
 	       // Load and show the External Status field
-	       woocommerce_wp_text_input( 
-		array( 
-		    'id'          => '_wcev_external_status[' . $variation->ID . ']', 
-		    'label'       => __( 'External Status', 'wc-external-variations' ), 
+	       woocommerce_wp_text_input(
+		array(
+		    'id'          => '_wcev_external_status[' . $variation->ID . ']',
+		    'label'       => __( 'External Status', 'wc-external-variations' ),
 		    'placeholder' => '',
 		    'desc_tip'    => 'true',
 		    'description' => __( 'Enter the status of the external product', 'wc-external-variations' ),
 		    'value'       => get_post_meta( $variation->ID, '_wcev_external_status', true )
 		)
 	       );
+
+         // Load and show the "Add to Cart button text"
+         woocommerce_wp_text_input(
+    array(
+        'id'          => '_wcev_external_add_to_cart_text[' . $variation->ID . ']',
+        'label'       => __( 'External "Add To Cart" Text', 'wc-external-variations' ),
+        'placeholder' => '',
+        'desc_tip'    => 'true',
+        'description' => __( 'Enter the text for the "Add to Cart Button"', 'wc-external-variations' ),
+        'value'       => get_post_meta( $variation->ID, '_wcev_external_add_to_cart_text', true )
+    )
+         );
 	    }
 
 	    /**
@@ -244,8 +269,13 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		if ( isset( $_POST['_wcev_external_status'][ $variation_id ] ) ) {
 	    	    update_post_meta( $variation_id, '_wcev_external_status',  wc_clean( $_POST['_wcev_external_status'][ $variation_id ] ) );
 		}
+
+    // Save the External Add To Cart text field
+		if ( isset( $_POST['_wcev_external_add_to_cart_text'][ $variation_id ] ) ) {
+	    	    update_post_meta( $variation_id, '_wcev_external_add_to_cart_text',  wc_clean( $_POST['_wcev_external_add_to_cart_text'][ $variation_id ] ) );
+		}
 	    }
-	 
+
 	    /**
 	      * Function to load the external URL into the front end HTML so the Javascript interceptor can find it and use it
 	      * Also provides shortcode support for the external URL which can be used to set standard links across the installation.
@@ -264,6 +294,11 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
                 // Set setting fields
                 $data['_wcev_link_target']  = WC_Admin_Settings::get_option('wcev_links_target', 'new_window');
+
+                // Set 'add to cart' button text
+                $settings_text = WC_Admin_Settings::get_option('wcev_add_to_cart_text', '');
+                $data_text = sanitize_text_field( get_post_meta( $variation->get_id(), '_wcev_external_add_to_cart_text', true ) );
+                $data['_wcev_add_to_cart_text']  = !empty( $data_text ) ? $data_text : $settings_text;
 		    }
 
             // Unset the global variable used for shortcodes
@@ -271,7 +306,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
             // Return data for the frond end
             return $data;
-	    } 
+	    }
 
 	     /**
 	      * This function loads Javascript files for this plugin which do the actual interception of the Add To Cart clicks

--- a/wc-external-variations.php
+++ b/wc-external-variations.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WC External Variations
  * Plugin URI: https://github.com/impossibledreams/wc-external-variations
- * Version: 1.0.6
+ * Version: 1.0.7
  *
  * GitHub Plugin URI: https://github.com/impossibledreams/wc-external-variations
  * Description: Adds basic support for external products to WooCommerce variations/variable products
@@ -11,7 +11,7 @@
  * Contributors: impossibledreams, yakovsh
  *
  * WC requires at least: 4.0.0
- * WC tested up to: 4.1.1
+ * WC tested up to: 4.4.0
  *
  * Copyright: Copyright (c) 2018-2020 Impossible Dreams Network (email: wp-plugins@impossibledreams.net)
  * License: GNU General Public License v3.0


### PR DESCRIPTION

= 1.0.7 =
* Tested with Wordpress v5.5 and WooCommerce v4.4.1
* Added ability to change the 'Add to Cart' text on global and variation-specific basis (#3).